### PR TITLE
21: Updated lists to not be in paragraph

### DIFF
--- a/src/body/preliminaries/programming_overview/c_style_syntax.adoc
+++ b/src/body/preliminaries/programming_overview/c_style_syntax.adoc
@@ -70,6 +70,7 @@ It's a good question, because the answer is often driven by opinion or bias.
 
 Here, "widely used and in demand" means that the language has consistently been among the top 10 in rankings of popular languages.
 I use a couple widely-known rankings for this:
+
 * The http://www.tiobe.com/tiobe-index/[Tiobe Index]
 * The http://pypl.github.io/PYPL.html[PYPL PopularitY of Programming Language Index]
 

--- a/src/body/preliminaries/programming_overview/computers_and_programs.adoc
+++ b/src/body/preliminaries/programming_overview/computers_and_programs.adoc
@@ -89,7 +89,7 @@ These instructions include both data, and the operations on that data.
 
 The program usually does not just represent the data itself, but also _metadata._
 Metadata is "data about data," and includes things like the data's type (e.g. number vs. letter) or location in memory.
-If you think of data as "nouns," you could think of medatata as "adjectives."
+If you think of data as "nouns," you could think of metadata as "adjectives."
 
 Of course, a program must also represent operations on that data.
 The operations constitute the _logic_ of the program.
@@ -174,7 +174,7 @@ Compilation and interpretation are covered in later chapters.
 
 Programming languages, like human languages, have sets of rules that specify what is and isn't valid in that language.
 The set of rules for each language is called the language's _grammar._
-The grammar of a programming language is defined by the languages syntax and semantics.
+The grammar of a programming language is defined by the language's syntax and semantics.
 
 The _syntax_ of a programming language determines what constitutes _a well-formed string_ in that language.
 It has rules that determine the language's alphabet, how characters are interpreted symbolically, and so forth.

--- a/src/body/preliminaries/tools/ide.adoc
+++ b/src/body/preliminaries/tools/ide.adoc
@@ -1,5 +1,6 @@
 = Integrated Development Environments
 Include all the features of a source code editor, plus:
+
 * One-click build and run of a project
 * Integrated command-line interface
 * Hierarchical view of classes, objects, methods, etc.
@@ -9,6 +10,7 @@ Include all the features of a source code editor, plus:
 * Integration with VCS
 
 == Popular IDE's
+
 * Visual Studio (Microsoft, closed-source)
 ** Xamarin Studio
 

--- a/src/body/preliminaries/tools/vcs.adoc
+++ b/src/body/preliminaries/tools/vcs.adoc
@@ -1,4 +1,4 @@
-= Version Control Systems ##
+= Version Control Systems
 
 * A directed acyclical graph (DAG) in graph theory
 


### PR DESCRIPTION
ASCIIDoc lists must have a space above and below them.

Additionally fixed some minor spelling errors and typos.